### PR TITLE
Allow post()/put()/patch() for any Object

### DIFF
--- a/src/main/groovy/com/greenmoonsoftware/tea/Tea.groovy
+++ b/src/main/groovy/com/greenmoonsoftware/tea/Tea.groovy
@@ -175,17 +175,17 @@ class Tea {
         return this;
     }
 
-    def Tea post(String url, Map json = null, String requestContentType = 'application/json'){
+    def Tea post(String url, Object json = null, String requestContentType = 'application/json'){
         action = [method:"post", params:[path:url, body:json, requestContentType: requestContentType]]
         return this
     }
 
-    def Tea put(String url, Map json = null, String requestContentType = 'application/json'){
+    def Tea put(String url, Object json = null, String requestContentType = 'application/json'){
         action = [method:"put", params:[path:url, body:json, requestContentType: requestContentType]]
         return this
     }
 
-    def Tea patch(String url, Map json = null, String requestContentType = 'application/json') {
+    def Tea patch(String url, Object json = null, String requestContentType = 'application/json') {
         action = [method:"patch", params:[path:url, body:json, requestContentType: requestContentType]]
         return this
     }


### PR DESCRIPTION
Allow post()/put()/patch() for any Object, not just Map, as the type will be sorted out at runtime and treated sanely by the underlying HttpBuilder/json-lib - this allows us to send in a String of JSON to bypass issues with json-lib treating null values as "ignored" rather than "present and set to null".