### PR TITLE
Fix type issue where Map is required by HttpMetaData, instead of any Object

### DIFF
--- a/src/main/groovy/com/greenmoonsoftware/tea/HttpMetaData.groovy
+++ b/src/main/groovy/com/greenmoonsoftware/tea/HttpMetaData.groovy
@@ -6,7 +6,7 @@ class HttpMetaData {
     String method = ''
     Map requestHeaders = [:]
     Map queryParameters = [:]
-    Map requestBody = [:]
+    def requestBody = [:]
     Map responseHeaders = [:]
     def responseBody
     String responseStatus = ''


### PR DESCRIPTION
My last PR caused an issue when using String (or other non-Map types) because the recording process still required a Map. That problem is fixed by this pull request.