### PR TITLE
Change type of HttpMetaData.responseStatus from String to int

### DIFF
--- a/src/main/groovy/com/greenmoonsoftware/tea/HttpMetaData.groovy
+++ b/src/main/groovy/com/greenmoonsoftware/tea/HttpMetaData.groovy
@@ -9,5 +9,5 @@ class HttpMetaData {
     def requestBody = [:]
     Map responseHeaders = [:]
     def responseBody
-    String responseStatus = ''
+    int responseStatus
 }


### PR DESCRIPTION
It seems to make sense to have this as an `int`, rather than a `String`, to match `assertStatus()` (which, admittedly, is working fine). Where we actually had an issue with it being a `String` is when we used a custom recorder to capture the value and then tried to do `assert response.responseStatus == HttpStatus.SC_OK` and the like; the match fails, with the usual bizarre Groovy test error that 200 is not equal to 200. :smile: 